### PR TITLE
Fix impish-security is  no longer available; Update buld wheel based …

### DIFF
--- a/tests/hubapi/demohub/docker-compose.yml
+++ b/tests/hubapi/demohub/docker-compose.yml
@@ -42,7 +42,6 @@ services:
       - "discovery.type=single-node"
       - "xpack.security.enabled=false"
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - "xpack.security.enabled=false"
       - AWS_ACCESS_KEY=${AWS_ACCESS_KEY}
       - AWS_SECRET_KEY=${AWS_SECRET_KEY}
     image: elasticsearch:8.2.3


### PR DESCRIPTION
- Fix impish-security is  no longer available
- Update buld wheel based image to 22.04
- Update build instructions